### PR TITLE
Implement basic file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,33 @@ formsquare(checkboxForm);
 // []
 ```
 
+### Files
+
+Inputs with the type of “file” (`<input type="file">`) result in a
+promise containing the file object. File inputs with `multiple` set to
+true will result in promise of an array of such objects.
+
+```html
+<form>
+  <input type="file">
+</form>
+```
+
+Granted that a user uploaded the file `foo.txt` conatining the text
+`foo`:
+
+```js
+formsquare(document.forms[0]).then((file) => {
+  console.log(file);
+});
+
+// {
+//   "body": "Zm9v",
+//   "name": "foo.txt",
+//   "type": "text/plain"
+// }
+```
+
 Alternatives
 ------------
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -169,6 +169,28 @@
         </script>
       </div>
 
+      <div class="example" id="readme-example-files">
+        <h3>Files</h3>
+
+        <form>
+          <input type="file" multiple>
+        </form>
+
+        <output></output>
+
+        <script>
+          (function() {
+          var div = document.getElementById("readme-example-files");
+
+          var form = div.querySelector("form");
+          var output = div.querySelector("output");
+          formsquare(form).then((data) => {
+            output.textContent = JSON.stringify(data);
+          });
+          }())
+        </script>
+      </div>
+
       <div class="example" id="readme-example-form-collection">
         <h3>Collections of forms</h3>
 

--- a/src/files.js
+++ b/src/files.js
@@ -1,0 +1,25 @@
+export function readFile(file) {
+  if (!file) {
+    return Promise.resolve(null);
+  }
+
+  let reader = new FileReader();
+  let loaded = new Promise((resolve, reject) => {
+    reader.addEventListener("load", resolve, false);
+    reader.addEventListener("error", reject, false);
+    reader.addEventListener("abort", reject, false);
+  });
+
+  reader.readAsDataURL(file);
+
+  return loaded.then((event) => {
+    // data:text/plain;base64,Zm9vCg
+    let [type, body] = event.target.result.split(";");
+
+    return {
+      "body": body.slice(7),
+      "name": file.name,
+      "type": type.slice(5),
+    };
+  });
+}

--- a/src/formsquare.js
+++ b/src/formsquare.js
@@ -5,10 +5,13 @@ import {
   extendUniq,
   filter,
   flatMap,
+  map,
   reduce,
   selectedValues,
   startsWith,
 } from "./utils";
+
+import {readFile} from "./files";
 
 
 const digitRE = /^\s*\d+\s*$/;
@@ -97,6 +100,18 @@ function getValue(input) {
 
   if (input.getAttribute("type") === "week") {
     return getWeek(input.value) || input.getAttribute("value");
+  }
+
+  if (input.type === "file") {
+    if (input.multiple) {
+      if (input.files.length === 0) {
+        return Promise.resolve([]);
+      }
+
+      return Promise.all(map(readFile, input.files));
+    }
+
+    return readFile(input.files[0]);
   }
 
   return input.value;

--- a/src/utils.js
+++ b/src/utils.js
@@ -64,7 +64,7 @@ export function flatMap(fn, arr) {
   }, [], arr);
 }
 
-function map(fn, arr) {
+export function map(fn, arr) {
   let mapped = [];
   let len = arr.length;
 

--- a/tests/files.test.js
+++ b/tests/files.test.js
@@ -1,0 +1,20 @@
+import {readFile} from "../src/files";
+import test from "tape";
+
+
+test("Files", ({deepEqual, plan}) => {
+  plan(1);
+
+  readFile(new File(["foo"], "foo.txt", {"type": "text/plain"}))
+    .then((file) => {
+      deepEqual(
+        file,
+        {
+          "body": "Zm9v",
+          "name": "foo.txt",
+          "type": "text/plain",
+        },
+        "Base64 encodes the content"
+      );
+    });
+});

--- a/tests/test.js
+++ b/tests/test.js
@@ -16,7 +16,7 @@ test("Named exports", ({equal, ok, plan}) => {
 });
 
 test("Types", ({deepEqual, equal, plan}) => {
-  plan(9);
+  plan(10);
 
   deepEqual(tform(), null, "null (empty form)");
 
@@ -67,6 +67,11 @@ test("Types", ({deepEqual, equal, plan}) => {
     new Date("1989-03-10T21:00:44"),
     "Datetime-local"
   );
+
+  // We are not able to test real file input in real browsers:
+  tform([input({"type": "file"})]).then((file) => {
+    deepEqual(file, null, "File");
+  });
 });
 
 test("Collection types", ({deepEqual, plan}) => {
@@ -154,7 +159,7 @@ test("Objects", ({deepEqual, plan}) => {
 });
 
 test("Form elements", ({deepEqual, equal, plan}) => {
-  plan(8);
+  plan(9);
 
   let loremIpsum = "Lorem ipsum dolar sit amet";
 
@@ -207,6 +212,15 @@ test("Form elements", ({deepEqual, equal, plan}) => {
     [],
     "Select multiple -- empty"
   );
+
+  // We are not able to test real file inputs in real browsers.
+  tform([input({"type": "file", "multiple": true})]).then((files) => {
+    deepEqual(
+      files,
+      [],
+      "File input multiple -- empty"
+    );
+  });
 
   equal(
     tform([textarea(loremIpsum)]),


### PR DESCRIPTION
We return a promise of files with base64 encoded body. If the input
element has `multiple` set to `true`, we return a promise of a list of
such file.

Closes #1